### PR TITLE
Create pre-release for dirty repos, implements #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ gitversion {
 
 Appends a suffix like `20221213T001324Z-SNAPSHOT` to every pre-release that's not on a main branch.
 
-You can set a suffix unconfitionally by omitting `when` and the closure:
+You can set a suffix unconditionally by omitting `when` and the closure:
 
 ```groovy
 gitversion {
@@ -334,6 +334,12 @@ gitVersion {
     ...
 }
 ```
+
+## Dirty working trees
+
+At present a dirty working tree always results in a pre-release version. Depending on the last tag, either the pre-release or the minor version
+is incremented. This prevents accidental relase builds when after a file has been changed.
+
 
 ## License
 

--- a/gradle-plugin/src/test/java/org/dmfs/gradle/gitversion/tasks/VersionTaskTest.java
+++ b/gradle-plugin/src/test/java/org/dmfs/gradle/gitversion/tasks/VersionTaskTest.java
@@ -39,31 +39,36 @@ class VersionTaskTest
                 }
             },
             stdoutCaptured(stdProvider ->
-                withTempFolder(tempDir ->
-                    withRepository(getClass().getClassLoader().getResource("0.0.2-alpha.1.bundle"),
-                        tempDir,
-                        "main",
-                        repository ->
-                            given(
-                                () ->
-                                {
-                                    Project p = ProjectBuilder.builder().withProjectDir(tempDir).build();
-                                    p.getPluginManager().apply("org.dmfs.gitversion");
-                                    ((GitVersionConfig) p.getExtensions().getByName("gitVersion")).mChangeTypeStrategy = new Strategy();
-                                    ((GitVersionConfig) p.getExtensions().getByName("gitVersion")).mChangeTypeStrategy.mChangeTypeStrategies.addAll(
-                                        asList(
-                                            MAJOR.when(new CommitMessage(new Contains("#major"))),
-                                            MINOR.when(new CommitMessage(new Contains("#minor"))),
-                                            PATCH.when(new CommitMessage(new Contains("#patch"))),
-                                            UNKNOWN.when(((repository1, commit, branches) -> true))));
-                                    return p;
-                                },
-                                project -> having(
-                                    "stdout",
-                                    proc -> repo -> proc.process(project),
-                                    processes(() -> stdProvider,
-                                        having(Generator::next, containsString("0.0.2-alpha.1"))
-                                    )))))));
+                withTempFolder(
+                    userHome ->
+                        withTempFolder(tempDir ->
+                            withRepository(getClass().getClassLoader().getResource("0.0.2-alpha.1.bundle"),
+                                tempDir,
+                                "main",
+                                repository ->
+                                    given(
+                                        () ->
+                                        {
+                                            Project p = ProjectBuilder.builder()
+                                                .withProjectDir(tempDir)
+                                                .withGradleUserHomeDir(userHome)
+                                                .build();
+                                            p.getPluginManager().apply("org.dmfs.gitversion");
+                                            ((GitVersionConfig) p.getExtensions().getByName("gitVersion")).mChangeTypeStrategy = new Strategy();
+                                            ((GitVersionConfig) p.getExtensions().getByName("gitVersion")).mChangeTypeStrategy.mChangeTypeStrategies.addAll(
+                                                asList(
+                                                    MAJOR.when(new CommitMessage(new Contains("#major"))),
+                                                    MINOR.when(new CommitMessage(new Contains("#minor"))),
+                                                    PATCH.when(new CommitMessage(new Contains("#patch"))),
+                                                    UNKNOWN.when(((repository1, commit, branches) -> true))));
+                                            return p;
+                                        },
+                                        project -> having(
+                                            "stdout",
+                                            proc -> repo -> proc.process(project),
+                                            processes(() -> stdProvider,
+                                                having(Generator::next, containsString("0.0.2-alpha.1"))
+                                            ))))))));
 
     }
 


### PR DESCRIPTION
This commit ensures a dirty repo always results in a pre-release version, even if the last commit is tagged with a release.