### PR TITLE
Fix publishing, fixes #59

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.dmfs.gitversion" version "0.12.0"
+    id "org.dmfs.gitversion" version "0.13.0"
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
 }
 
@@ -54,5 +54,17 @@ allprojects {
     group 'org.dmfs'
     repositories {
         mavenCentral()
+    }
+}
+
+gradle.taskGraph.whenReady {
+    tasks.withType(PublishToMavenRepository) { PublishToMavenRepository t ->
+        if ( t.repository == null ) {
+            logger.info( "Task `{}` had null repository", t.path )
+        }
+        else if ( t.repository.name == "sonatype" ) {
+            logger.lifecycle( "Disabling task `{}` because it publishes to Sonatype", t.path )
+            t.enabled = false
+        }
     }
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -55,3 +55,15 @@ pluginBundle {
         }
     }
 }
+
+gradle.taskGraph.whenReady {
+    tasks.withType(PublishToMavenRepository) { PublishToMavenRepository t ->
+        if ( t.repository == null ) {
+            logger.info( "Task `{}` had null repository", t.path )
+        }
+        else if ( t.repository.name == "sonatype" ) {
+            logger.lifecycle( "Disabling task `{}` because it publishes to Sonatype", t.path )
+            t.enabled = false
+        }
+    }
+}


### PR DESCRIPTION
This change ensures the nexus publishing task only publishes the gitversion-dsl artifacts.