### PR TITLE
Ensure SNAPSHOT times are stable, #61

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Examples
 gitversion {
     ...
     suffixes {
-        append ".${new Date().format("yyyyMMdd'T'HHmmss'Z'")}-SNAPSHOT" when {
+        append ".${new Date().format("yyyy-MM-dd")}-SNAPSHOT" when {
             branch not(matches(~/main/))
         }
     }
@@ -225,7 +225,7 @@ gitversion {
 }
 ```
 
-Appends a suffix like `20221213T001324Z-SNAPSHOT` to every pre-release that's not on a main branch.
+Appends a suffix like `2022-12-13-SNAPSHOT` to every pre-release that's not on a main branch.
 
 You can set a suffix unconditionally by omitting `when` and the closure:
 
@@ -233,13 +233,28 @@ You can set a suffix unconditionally by omitting `when` and the closure:
 gitversion {
     ...
     suffixes {
-        append ".${new Date().format("yyyyMMdd'T'HHmmss'Z'")}-SNAPSHOT"
+        append ".${new Date().format("yyyy-MM-dd")}-SNAPSHOT"
     }
     ...
 }
 ```
 
-If no suffixes are specified, the suffix `".${new Date().format("yyyyMMdd'T'HHmmss'Z'")}-SNAPSHOT"` is added to every pre-release.
+Unconditional suffixes always match, hence any `append` clause following an unconditional suffix will never be applied.
+
+If no suffixes are specified, the suffix `".<timestamp>-SNAPSHOT"` is added to every pre-release where `<timestamp>` is either the date and time
+(in UTC and RFC 5545 notation) of the HEAD commit in case the working tree is clean or the current date and time if the working tree is dirty.
+
+In order to apply the default suffix conditionally you can use the special suffix `DEFAULT` like
+
+```groovy
+gitversion {
+    ...
+    suffixes {
+        append DEFAULT when { branch not(matches(~/main/)) }
+    }
+    ...
+}
+```
 
 To disable any suffix use
 
@@ -339,7 +354,6 @@ gitVersion {
 
 At present a dirty working tree always results in a pre-release version. Depending on the last tag, either the pre-release or the minor version
 is incremented. This prevents accidental relase builds when after a file has been changed.
-
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.dmfs.gitversion" version "0.13.0"
+    id "org.dmfs.gitversion" version "0.14.1"
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
 }
 

--- a/gitversion-dsl/build.gradle
+++ b/gitversion-dsl/build.gradle
@@ -22,18 +22,20 @@ sourceSets {
 dependencies {
     compileOnly 'org.codehaus.groovy:groovy-all:2.5.19'
     implementation "org.dmfs:semver:0.1.0"
+    implementation "org.dmfs:rfc5545-datetime:0.3"
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.2.0.202206071550-r'
     implementation 'org.dmfs:srcless-annotations:0.2.0'
-    implementation "org.dmfs:jems2:2.11.1"
+    implementation "org.dmfs:jems2:2.14.0"
     annotationProcessor 'org.dmfs:srcless-processors:0.2.0'
 
     testImplementation 'org.codehaus.groovy:groovy-all:2.5.19'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
-    testImplementation "org.dmfs:jems2-testing:2.11.1"
+    testImplementation "org.dmfs:jems2-testing:2.14.0"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.saynotobugs:confidence-core:0.5.1"
+    testImplementation "org.saynotobugs:confidence-core:0.8.1"
+    testImplementation "org.saynotobugs:confidence-test:0.8.1"
     testImplementation "com.google.guava:guava:31.1-jre"
     testAnnotationProcessor 'org.dmfs:srcless-processors:0.2.0'
 }

--- a/gitversion-dsl/src/main/java/org/dmfs/gitversion/git/GitVersion.java
+++ b/gitversion-dsl/src/main/java/org/dmfs/gitversion/git/GitVersion.java
@@ -47,18 +47,19 @@ public final class GitVersion implements FragileFunction<Repository, Version, Ex
     {
         try (RevWalk revWalk = new RevWalk(repository))
         {
+            RevCommit head = repository.parseCommit(repository.resolve("HEAD"));
             Version version = adjustForDirtyRepo(repository,
                 readVersion(
                     repository,
                     revWalk,
-                    repository.parseCommit(repository.resolve("HEAD")),
+                    head,
                     versions(repository),
                     mPreReleaseStrategy.value(repository.getBranch())));
 
             return new Backed<>(
                 new Zipped<>(
                     version.preRelease(),
-                    mSuffixes.suffix(repository, repository.parseCommit(repository.resolve("HEAD")), repository.getBranch()),
+                    mSuffixes.suffix(repository, head, repository.getBranch()),
                     (current, suffix) -> new PreRelease(version, current + suffix)
                 ),
                 version).value();

--- a/gitversion-dsl/src/main/java/org/dmfs/gitversion/git/predicates/IsDirty.java
+++ b/gitversion-dsl/src/main/java/org/dmfs/gitversion/git/predicates/IsDirty.java
@@ -1,0 +1,31 @@
+package org.dmfs.gitversion.git.predicates;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+
+import java.util.function.Predicate;
+
+
+public final class IsDirty implements Predicate<Repository>, org.dmfs.jems2.Predicate<Repository>
+{
+    @Override
+    public boolean test(Repository repository)
+    {
+        return satisfiedBy(repository);
+    }
+
+
+    @Override
+    public boolean satisfiedBy(Repository repository)
+    {
+        try
+        {
+            return !new Git(repository).diff().call().isEmpty() || !new Git(repository).diff().setCached(true).call().isEmpty();
+        }
+        catch (GitAPIException e)
+        {
+            throw new RuntimeException("Can't determine repository state", e);
+        }
+    }
+}

--- a/gitversion-dsl/src/test/java/org/dmfs/gitversion/git/SuffixesTest.java
+++ b/gitversion-dsl/src/test/java/org/dmfs/gitversion/git/SuffixesTest.java
@@ -1,13 +1,29 @@
 package org.dmfs.gitversion.git;
 
 import org.dmfs.gitversion.dsl.Conditions;
+import org.dmfs.gitversion.git.changetypefacories.FirstOf;
+import org.dmfs.gitversion.git.changetypefacories.condition.CommitMessage;
+import org.dmfs.gitversion.git.predicates.Contains;
+import org.dmfs.rfc5545.DateTime;
+import org.dmfs.semver.VersionSequence;
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
 
 import groovy.lang.Closure;
 
+import static org.dmfs.gitversion.dsl.utils.Matchers.given;
 import static org.dmfs.gitversion.dsl.utils.Qualities.present;
+import static org.dmfs.gitversion.dsl.utils.Tools.withRepository;
+import static org.dmfs.gitversion.dsl.utils.Tools.withTempFolder;
+import static org.dmfs.gitversion.git.ChangeType.*;
+import static org.dmfs.jems2.hamcrest.matchers.LambdaMatcher.having;
+import static org.dmfs.jems2.hamcrest.matchers.function.FragileFunctionMatcher.associates;
 import static org.dmfs.jems2.mockito.Mock.mock;
 import static org.saynotobugs.confidence.Assertion.assertThat;
 import static org.saynotobugs.confidence.quality.Core.*;
@@ -15,12 +31,60 @@ import static org.saynotobugs.confidence.quality.Core.*;
 
 class SuffixesTest
 {
+    ChangeTypeStrategy mStrategy = new FirstOf(
+        MAJOR.when(new CommitMessage(new Contains("#major"))),
+        MINOR.when(new CommitMessage(new Contains("#minor"))),
+        PATCH.when(new CommitMessage(new Contains("#patch"))),
+        NONE.when(new CommitMessage(new Contains("#trivial"))),
+        UNKNOWN.when(((treeWalk, commit, branches) -> true))
+    );
+
+
     @Test
-    void testDefault()
+    void testDefaultClean()
     {
-        assertThat(new Suffixes(),
-            has("default", s -> s.suffix(mock(Repository.class), mock(RevCommit.class), "branchName"),
-                is(present(matchesPattern(".20\\d{6}T\\d{6}Z-SNAPSHOT")))));
+        MatcherAssert.assertThat(new GitVersion(mStrategy, new Suffixes(), ignored -> "alpha"),
+            withTempFolder(tempDir ->
+                withRepository(getClass().getClassLoader().getResource("0.1.0-alpha.bundle"),
+                    tempDir,
+                    "main",
+                    repo ->
+
+                        associates(repo,
+                            having(
+                                v -> new VersionSequence(new WithoutBuildMeta(v)).toString(),
+                                Matchers.equalTo("0.1.0-alpha.20220116T191427Z-SNAPSHOT"))))
+            ));
+    }
+
+
+    @Test
+    void testDefaultDirty()
+    {
+        MatcherAssert.assertThat(new GitVersion(mStrategy, new Suffixes(), ignored -> "alpha"),
+            withTempFolder(tempDir ->
+                withRepository(getClass().getClassLoader().getResource("0.1.0-alpha.bundle"),
+                    tempDir,
+                    "main",
+                    repo ->
+                        given(
+                            () -> {
+                                new File(tempDir, "dirty").createNewFile();
+                                new Git(repo).add().addFilepattern("dirty").call();
+                                return true;
+                            },
+                            ignored ->
+                                associates(repo,
+                                    having(
+                                        v -> new VersionSequence(new WithoutBuildMeta(v)).toString(),
+                                        Matchers.allOf(
+                                            Matchers.matchesPattern("0\\.1\\.0-alpha.1\\.20\\d{6}T\\d{6}Z-SNAPSHOT"),
+                                            having(version -> version.substring(14, 30),
+                                                having(DateTime::parse,
+                                                    having(DateTime::getTimestamp,
+                                                        having(Number::doubleValue,
+                                                            Matchers.closeTo(System.currentTimeMillis(), 1000d)))))))
+                                )))));
     }
 
 

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -17,15 +17,15 @@ dependencies {
     implementation "org.dmfs:semver:0.1.0"
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.2.0.202206071550-r'
     implementation 'org.dmfs:srcless-annotations:0.2.0'
-    implementation "org.dmfs:jems2:2.11.1"
+    implementation "org.dmfs:jems2:2.14.0"
     annotationProcessor 'org.dmfs:srcless-processors:0.2.0'
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
-    testImplementation "org.dmfs:jems2-testing:2.11.1"
+    testImplementation "org.dmfs:jems2-testing:2.14.0"
     testImplementation "org.hamcrest:hamcrest:2.2"
-    testImplementation "org.saynotobugs:confidence-core:0.5.1"
+    testImplementation "org.saynotobugs:confidence-core:0.8.1"
     testAnnotationProcessor 'org.dmfs:srcless-processors:0.2.0'
 }
 
@@ -58,11 +58,10 @@ pluginBundle {
 
 gradle.taskGraph.whenReady {
     tasks.withType(PublishToMavenRepository) { PublishToMavenRepository t ->
-        if ( t.repository == null ) {
-            logger.info( "Task `{}` had null repository", t.path )
-        }
-        else if ( t.repository.name == "sonatype" ) {
-            logger.lifecycle( "Disabling task `{}` because it publishes to Sonatype", t.path )
+        if (t.repository == null) {
+            logger.info("Task `{}` had null repository", t.path)
+        } else if (t.repository.name == "sonatype") {
+            logger.lifecycle("Disabling task `{}` because it publishes to Sonatype", t.path)
             t.enabled = false
         }
     }

--- a/gradle-plugin/src/main/java/org/dmfs/gradle/gitversion/GitVersionPlugin.java
+++ b/gradle-plugin/src/main/java/org/dmfs/gradle/gitversion/GitVersionPlugin.java
@@ -35,6 +35,7 @@ public final class GitVersionPlugin implements Plugin<Project>
             {
                 private final Single<String> mVersion = new Frozen<>(
                     () -> {
+                        long start = System.currentTimeMillis();
                         try (Repository repo = ProjectRepositoryFunction.INSTANCE.value(project))
                         {
                             return new VersionSequence(
@@ -53,6 +54,10 @@ public final class GitVersionPlugin implements Plugin<Project>
                         catch (Exception e)
                         {
                             throw new RuntimeException(e);
+                        }
+                        finally
+                        {
+                            project.getLogger().debug("gitVersion execution time: {} ms", System.currentTimeMillis() - start);
                         }
                     }
                 );

--- a/gradle-plugin/src/test/java/org/dmfs/gradle/gitversion/tasks/VersionTaskTest.java
+++ b/gradle-plugin/src/test/java/org/dmfs/gradle/gitversion/tasks/VersionTaskTest.java
@@ -67,7 +67,7 @@ class VersionTaskTest
                                             "stdout",
                                             proc -> repo -> proc.process(project),
                                             processes(() -> stdProvider,
-                                                having(Generator::next, containsString("0.0.2-alpha.1"))
+                                                having(Generator::next, containsString("0.0.2-alpha.1.20220116T202206Z-SNAPSHOT"))
                                             ))))))));
 
     }


### PR DESCRIPTION
This uses the commit time of the HEAD commit as the SNAPSHOT time, unless the working tree is dirty, in which case the current time is still used.